### PR TITLE
2n markov

### DIFF
--- a/Oanda/Modules/Predictor/Predictor.py
+++ b/Oanda/Modules/Predictor/Predictor.py
@@ -21,6 +21,7 @@ class Predictor():
             loaded_dict = torch.load(pretrained_path)
             model.load_state_dict(loaded_dict['state_dict']) # Loads pretrained model
             model.dt_settings = loaded_dict['dt_settings']
+            model.notes = loaded_dict['notes']
         
     def predict(*args): # Input is model dependent
         if len(args) == 1:

--- a/Oanda/Modules/Predictor/Predictor.py
+++ b/Oanda/Modules/Predictor/Predictor.py
@@ -18,7 +18,9 @@ class Predictor():
         model.eval()
 
         if pretrained_path is not None:
-            model.load_state_dict(torch.load(pretrained_path)) # Loads pretrained model
+            loaded_dict = torch.load(pretrained_path)
+            model.load_state_dict(loaded_dict['state_dict']) # Loads pretrained model
+            model.dt_settings = loaded_dict['dt_settings']
         
     def predict(*args): # Input is model dependent
         if len(args) == 1:

--- a/Oanda/Modules/Training/Models/markov_kernel.py
+++ b/Oanda/Modules/Training/Models/markov_kernel.py
@@ -1,0 +1,52 @@
+import torch.nn as nn
+import numpy as np
+
+def make_ordinal(n):
+    '''
+    Convert an integer into its ordinal representation::
+
+        make_ordinal(0)   => '0th'
+        make_ordinal(3)   => '3rd'
+        make_ordinal(122) => '122nd'
+        make_ordinal(213) => '213th'
+    '''
+    n = int(n)
+    suffix = ['th', 'st', 'nd', 'rd', 'th'][min(n % 10, 4)]
+    if 11 <= (n % 100) <= 13:
+        suffix = 'th'
+    return str(n) + suffix
+
+class MarkovKernel(nn.Module):
+    # Simple neural network for markov kernel
+    def __init__(self, input_size, hidden_size, output_size, dt_settings=None, regression=True):
+        super(MarkovKernel, self).__init__()
+        self.input_size = input_size
+        layer_list = [
+            nn.Linear(input_size, hidden_size[0]), # input size determines order of markov kernel
+            nn.Tanh(),]
+        for hidden_layer_index in np.arange(1, len( hidden_size ) ):
+          layer_list.append( nn.Linear( hidden_size[hidden_layer_index-1], \
+            hidden_size[hidden_layer_index]  ) ) # take in_features out_features into account
+          layer_list.append( nn.Tanh() ) 
+        
+        layer_list.append( nn.Linear(hidden_size[-1],  output_size ) )
+
+        if not regression:
+          layer_list.append(nn.Softmax())
+        
+        self.model = nn.Sequential( *layer_list ) #Unpacks list for sequential
+        
+        self.dt_settings = dt_settings
+        
+    def __str__(self):
+      return f"{make_ordinal(self.input_size)} order Markov Kernel model"
+    
+    def forward(self, value):
+        assert self.dt_settings is not None, "dt_settings required for using model. Have you loaded the model correctly?"
+        output = self.model(value)
+        return output
+    
+    # def classify(self, history):
+    #     classification = self.model(history[-1])
+    #     return classification
+        

--- a/Oanda/Modules/Training/Models/markov_kernel.py
+++ b/Oanda/Modules/Training/Models/markov_kernel.py
@@ -37,6 +37,7 @@ class MarkovKernel(nn.Module):
         self.model = nn.Sequential( *layer_list ) #Unpacks list for sequential
         
         self.dt_settings = dt_settings
+        self.notes = ''
         
     def __str__(self):
       return f"{make_ordinal(self.input_size)} order Markov Kernel model"

--- a/Oanda/Modules/Training/Trainer/misty.py
+++ b/Oanda/Modules/Training/Trainer/misty.py
@@ -97,7 +97,9 @@ def train(model, train_dataloader, val_dataloader, test_dataloader, optimizer, l
                             break
     test_acc = evaluate(test_dataloader, model, loss_fn, test=True)
 
-    save_dict = {'state_dict': model.state_dict(), 'dt_settings': model.dt_settings}
+    notes = ''
+
+    save_dict = {'state_dict': model.state_dict(), 'dt_settings': model.dt_settings, 'notes': notes}
 
     torch.save(save_dict, save_path)
 

--- a/Oanda/Modules/Training/Trainer/misty.py
+++ b/Oanda/Modules/Training/Trainer/misty.py
@@ -17,6 +17,10 @@ from pdb import set_trace
 
 
 def evaluate(val_dataloader, model, loss_fn, test=False):
+    """
+    NOTE: Last value in input should be most recent
+    TODO: Make this work for batched inputs
+    """
     losses = []
     accuracies = []
     # directions = []
@@ -30,9 +34,9 @@ def evaluate(val_dataloader, model, loss_fn, test=False):
         # The direction it should have is target - input
         # The direction it has is target - output
         # These should be the same
-        target_direction = target - input
+        target_direction = target - input[0,-1]
         target_direction /= torch.abs(target_direction)
-        if target == input:
+        if target == input[0,-1]:
             target_direction = torch.tensor([0])
 
         direction = target - output
@@ -93,7 +97,9 @@ def train(model, train_dataloader, val_dataloader, test_dataloader, optimizer, l
                             break
     test_acc = evaluate(test_dataloader, model, loss_fn, test=True)
 
-    torch.save(model.state_dict(), save_path)
+    save_dict = {'state_dict': model.state_dict(), 'dt_settings': model.dt_settings}
+
+    torch.save(save_dict, save_path)
 
     print(f"Max loss is {max(losses)}, mean loss is {np.mean(losses)}")
     # print(f"Max final loss is {max(final_losses)}, mean loss is {np.mean(final_losses)}")
@@ -113,8 +119,6 @@ def misty():
     Let's start with immediate (next timestep) value and uncertainty
     How do we do uncertainty though?
     """
-    hidden_sizes = [8]
-    model = markov_kernel_1n.MarkovKernel(hidden_sizes, 1) # Example
 ####################################
     # TODO: Add the value offsets to this
     args = retrieval.HistoryArgs()
@@ -128,11 +132,15 @@ def misty():
 
     # history = retrieval.history.download_history(instrument, 
     #                             start_time, granularity, count)
-    dt = [retrieval.gran_to_sec['D']]
+    dt = [2*retrieval.gran_to_sec['D'], retrieval.gran_to_sec['D']]
     inputs, targets = retrieval.history.retrieve_training_data(args, dt, only_close=True)
     random = False
     train_loader, val_loader, test_loader = retrieval.build_dataset(inputs, targets, val_split=0.4, test_split=0.1, random=random)
 
+    # Define model
+    hidden_sizes = [8]
+    markov_order = 2
+    model = markov_kernel.MarkovKernel(markov_order, hidden_sizes, 1, dt_settings = dt) # Example
     # train_dataloader = DataLoader(train_set, batch_size=1, # Larger batch size not yet implemented
     #                     shuffle=True, num_workers=0)
     # val_dataloader = DataLoader(val_set, batch_size=1, # Larger batch size not yet implemented
@@ -142,12 +150,12 @@ def misty():
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
     # loss_fn = nn.MSELoss() # TODO: Move this into model definition?
     loss_fn = nn.L1Loss()
-    no_epochs = 200
-    min_epochs = 20
+    no_epochs = 2
+    min_epochs = 20 # For early stopping
     # os.makedirs("")
     for i in range(1000):
         # Sets save_path as the first free slot in the pretrained models folder
-        save_path = f"Pre-trained Models/markov1n_{hidden_sizes}_{args.granularity}_i{i}.pt"
+        save_path = f"Pre-trained Models/markov{markov_order}n_{hidden_sizes}_{args.granularity}_i{i}.pt"
         if not os.path.isfile(save_path):
             break
 

--- a/Oanda/Tests/test_predictor.py
+++ b/Oanda/Tests/test_predictor.py
@@ -33,6 +33,7 @@ def Test(inputt):
     predictor = Predictor(model, prediction_time=24, pretrained_path=pt_path)
 
     print("dt: ", predictor.model.dt_settings)
+    print("model notes: ", predictor.model.notes)
     input = torch.tensor([1.08, 1.09])
     prediction = predictor(input)
     print(f"Input: {input} - prediction: {prediction}")

--- a/Oanda/Tests/test_predictor.py
+++ b/Oanda/Tests/test_predictor.py
@@ -2,10 +2,14 @@
     This file is a test script for the predictor class. Use for reference.
 """
 
-# import sys, os
-# import pathlib
-from Modules.Predictor.Predictor import Predictor
-from Modules.Training.Models import markov_kernel_1n
+import sys, os
+import pathlib
+# Specify path to look for Modules folder, based on current folder structure
+path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(1, path)
+from Modules.Predictor.Predictor import *
+from Modules.Training.Models import markov_kernel
+import Modules.Training.Retrieval as retrieval
 import torch
 # from Modules.Predictor.Predictor import *
 
@@ -13,19 +17,25 @@ def Test(inputt):
     # predictor = TestMarkovPredictor()
     # print(predictor.model_type)
     # print(predictor.predict())
+
+    # Data settings:
+    dt = [2*retrieval.gran_to_sec['D'], retrieval.gran_to_sec['D']]
+
     hidden_sizes = [8]
-    model = markov_kernel_1n.MarkovKernel(hidden_sizes, 1) # Example
+    model = markov_kernel.MarkovKernel(2, hidden_sizes, 1, dt_settings = None) # Example
+    
+    # Now we can find the dt values in model.dt_settings
+    
     granularity = "D"
 
-    pt_path = f"Pre-trained Models/markov1n_{hidden_sizes}_{granularity}_i1.pt"
+    # pt_path = f"Pre-trained Models/markov1n_{hidden_sizes}_{granularity}_i1.pt"
+    pt_path = "Pre-trained Models/markov2n_[8]_M1_i0.pt"
     predictor = Predictor(model, prediction_time=24, pretrained_path=pt_path)
 
-    input = torch.tensor([inputt])
+    print("dt: ", predictor.model.dt_settings)
+    input = torch.tensor([1.08, 1.09])
     prediction = predictor(input)
-
-    # print(f"Input: {input} - prediction: {prediction}")
-    
-    return input, prediction
+    print(f"Input: {input} - prediction: {prediction}")
 
 # if __name__=='__main__':
 #     main()


### PR DESCRIPTION
This includes a generic n-th order Markov kernel model. To use this, the dt_settings variable is required, which stores the offsets of each data point the model is trained for. This is now also added to the pretrained model file, in addition to a 'notes' field, in which a description of the trained model can be given.
NOTE: This PR breaks previous pretrained model files.